### PR TITLE
Add github action to release new version

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,10 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Notable changes
+    - title: bug fixes
+    - title: Other Changes

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,7 +11,10 @@ jobs:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: [ubuntu-latest, windows-latest, macos-latest]
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,7 +11,7 @@ jobs:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -13,7 +13,7 @@ jobs:
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [windows-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -23,6 +23,13 @@ jobs:
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -S Swirl
+      # cmake -B build -S Swirl -G "MinGW Makefiles"
+      run: |
+          if [ "${{ matrix.os }}" == "windows-latest" ]; then
+            cmake -B ${{github.workspace}}/build -S Swirl -G "MinGW Makefiles"
+          else
+            cmake -B ${{github.workspace}}/build -S Swirl
+          fi
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -30,14 +30,14 @@ jobs:
       # cmake -B build -S Swirl -G "MinGW Makefiles"
       run: |
           if [ "${{ matrix.os }}" == "windows-latest" ]; then
-            cmake -B ${{github.workspace}}/build -S Swirl -G "MinGW Makefiles"
+            cmake -B build -S Swirl -G "MinGW Makefiles"
           else
-            cmake -B ${{github.workspace}}/build -S Swirl
+            cmake -B build -S Swirl
           fi
 
     - name: Build
       # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      run: cmake --build build --config ${{env.BUILD_TYPE}}
       
     - name: Run app
       # Run the app to see if it works

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,6 +6,10 @@ env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,4 +1,4 @@
-name: test CMake application
+name: build app
 
 on: [push, pull_request]
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -S Swirl
+      # run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -S Swirl
       # cmake -B build -S Swirl -G "MinGW Makefiles"
       run: |
           if [ "${{ matrix.os }}" == "windows-latest" ]; then

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -17,7 +17,7 @@ jobs:
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     strategy:
       matrix:
-        os: [windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -26,13 +26,11 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      # run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -S Swirl
-      # cmake -B build -S Swirl -G "MinGW Makefiles"
       run: |
           if [ "${{ matrix.os }}" == "windows-latest" ]; then
-            cmake -B build -S Swirl -G "MinGW Makefiles"
+            cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -S Swirl -G "MinGW Makefiles"
           else
-            cmake -B build -S Swirl
+            cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -S Swirl
           fi
 
     - name: Build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,6 +1,6 @@
 name: build app
 
-on: [push, pull_request]
+# on: [push, pull_request]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
@@ -12,9 +12,6 @@ defaults:
 
 jobs:
   build:
-    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
-    # You can convert this to a matrix build if you need cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -24,8 +21,6 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: |
           if [ "${{ matrix.os }}" == "windows-latest" ]; then
             cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -S Swirl -G "MinGW Makefiles"
@@ -34,9 +29,7 @@ jobs:
           fi
 
     - name: Build
-      # Build your program with the given configuration
       run: cmake --build build --config ${{env.BUILD_TYPE}}
       
     - name: Run app
-      # Run the app to see if it works
       run: 	./build/swirl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
             mv build/swirl build/swirl-macos
             ./build/swirl-macos
           else
-            mv build/swirl build/swirl-Linux
+            mv build/swirl build/swirl-linux
             ./build/swirl-linux
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,8 +96,10 @@ jobs:
           if [ "${{ matrix.os }}" == "windows-latest" ]; then
             ./swirl-Windows.exe
           elif [ "${{ matrix.os }}" == "macos-latest" ]; then
-            ./swirl-MacOS
+            chmod +x swirl-MacOS
+            ./swirl-MacOS              
           else
+            chmod +x swirl-Linux
             ./swirl-Linux
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,126 @@
+# **what it does ?**
+# Take the given commit, run unit tests specifically on that sha, build and
+# package it, and then release to GitHub
+
+# **why it does ?**
+# Ensure an automated and tested release process
+
+# **when it does ?**
+# This will only run manually with a given sha and version
+
+name: Release to GitHub
+
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+       description: 'The last commit sha in the release'
+       required: true
+      version_number:
+       description: 'The release version number (i.e. 1.0.0, 0.0.1-alpha)'
+       required: true
+
+permissions:
+  contents: write # this is the permission that allows creating a new release
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.inputs.sha }}
+
+      - name: Configure CMake
+        run: |
+            if [ "${{ matrix.os }}" == "windows-latest" ]; then
+              cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -S Swirl -G "MinGW Makefiles"
+            else
+              cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -S Swirl
+            fi
+      
+      - name: Build
+        run: cmake --build build --config ${{env.BUILD_TYPE}}
+
+      - name: rename and run the app
+        run: |
+          if [ "${{ matrix.os }}" == "windows-latest" ]; then
+            mv build/swirl.exe build/swirl-$RUNNER_OS.exe
+            ./build/swirl-$RUNNER_OS.exe
+          else
+            mv build/swirl build/swirl-$RUNNER_OS
+            ./build/swirl-$RUNNER_OS
+          fi
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: binary
+          path: build/swirl-$RUNNER_OS*
+
+  test-build:
+    name: verify app
+
+    needs: [build]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: binary
+          path: .
+
+      - name: run the app
+        run: |
+          if [ "${{ matrix.os }}" == "windows-latest" ]; then
+            ./swirl-$RUNNER_OS.exe
+          else
+            ./swirl-$RUNNER_OS
+          fi
+
+  github-release:
+    name: GitHub Release
+
+    needs: test-build
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: binary
+          path: .
+
+      # Need to set an output variable because env variables can't be taken as input
+      # This is needed for the next step with releasing to GitHub
+      - name: Find release type
+        id: release_type
+        env:
+          IS_PRERELEASE: ${{ contains(github.event.inputs.version_number, 'alpha') ||  contains(github.event.inputs.version_number, 'beta') }}
+        run: |
+          echo "isPrerelease=$IS_PRERELEASE" >> $GITHUB_OUTPUT
+
+      - name: Creating GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: v${{github.event.inputs.version_number}}
+          tag_name: v${{github.event.inputs.version_number}}
+          prerelease: ${{ steps.release_type.outputs.isPrerelease }}
+          target_commitish: ${{github.event.inputs.sha}}
+          body: |
+            Hey this is a test release
+          files: |
+            swirl-Linux
+            swirl-macOS
+            swirl-Windows.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,11 +77,13 @@ jobs:
           path: build/swirl-*
 
   test-build:
+    strategy:
+        matrix:
+          os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     name: verify app
 
     needs: [build]
-
-    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/download-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,11 @@ on:
 permissions:
   contents: write # this is the permission that allows creating a new release
 
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,5 +132,5 @@ jobs:
             Hey this is a test release
           files: |
             swirl-Linux
-            swirl-macOS
+            swirl-MacOS
             swirl-Windows.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,18 +60,21 @@ jobs:
       - name: rename and run the app
         run: |
           if [ "${{ matrix.os }}" == "windows-latest" ]; then
-            mv build/swirl.exe build/swirl-$RUNNER_OS.exe
-            ./build/swirl-$RUNNER_OS.exe
+            mv build/swirl.exe build/swirl-Windows.exe
+            ./build/swirl-Windows.exe
+          elif [ "${{ matrix.os }}" == "macos-latest" ]; then
+            mv build/swirl build/swirl-MacOS
+            ./build/swirl-MacOS
           else
-            mv build/swirl build/swirl-$RUNNER_OS
-            ./build/swirl-$RUNNER_OS
+            mv build/swirl build/swirl-Linux
+            ./build/swirl-Linux
           fi
 
       - name: Upload binary
         uses: actions/upload-artifact@v2
         with:
           name: binary
-          path: build/swirl-$RUNNER_OS*
+          path: build/swirl-*
 
   test-build:
     name: verify app
@@ -89,9 +92,11 @@ jobs:
       - name: run the app
         run: |
           if [ "${{ matrix.os }}" == "windows-latest" ]; then
-            ./swirl-$RUNNER_OS.exe
+            ./swirl-Windows.exe
+          elif [ "${{ matrix.os }}" == "macos-latest" ]; then
+            ./swirl-MacOS
           else
-            ./swirl-$RUNNER_OS
+            ./swirl-Linux
           fi
 
   github-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@
 # **when it does ?**
 # This will only run manually with a given sha and version
 
-name: Release to GitHub
+name: Release new version
 
 on:
   workflow_dispatch:
@@ -21,10 +21,10 @@ on:
        required: true
 
 permissions:
-  contents: write # this is the permission that allows creating a new release
+  contents: write # permission to allow creating a new release
 
 env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  # Change CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
 
 
@@ -60,14 +60,14 @@ jobs:
       - name: rename and run the app
         run: |
           if [ "${{ matrix.os }}" == "windows-latest" ]; then
-            mv build/swirl.exe build/swirl-Windows.exe
-            ./build/swirl-Windows.exe
+            mv build/swirl.exe build/swirl-windows.exe
+            ./build/swirl-windows.exe
           elif [ "${{ matrix.os }}" == "macos-latest" ]; then
-            mv build/swirl build/swirl-MacOS
-            ./build/swirl-MacOS
+            mv build/swirl build/swirl-macos
+            ./build/swirl-macos
           else
             mv build/swirl build/swirl-Linux
-            ./build/swirl-Linux
+            ./build/swirl-linux
           fi
 
       - name: Upload binary
@@ -76,37 +76,10 @@ jobs:
           name: binary
           path: build/swirl-*
 
-  test-build:
-    strategy:
-        matrix:
-          os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    name: verify app
-
-    needs: [build]
-
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: binary
-          path: .
-
-      - name: run the app
-        run: |
-          if [ "${{ matrix.os }}" == "windows-latest" ]; then
-            ./swirl-Windows.exe
-          elif [ "${{ matrix.os }}" == "macos-latest" ]; then
-            chmod +x swirl-MacOS
-            ./swirl-MacOS              
-          else
-            chmod +x swirl-Linux
-            ./swirl-Linux
-          fi
-
   github-release:
     name: GitHub Release
 
-    needs: test-build
+    needs: build
 
     runs-on: ubuntu-latest
 
@@ -132,9 +105,8 @@ jobs:
           tag_name: v${{github.event.inputs.version_number}}
           prerelease: ${{ steps.release_type.outputs.isPrerelease }}
           target_commitish: ${{github.event.inputs.sha}}
-          body: |
-            Hey this is a test release
+          generate_release_notes: true
           files: |
-            swirl-Linux
-            swirl-MacOS
-            swirl-Windows.exe
+            swirl-linux
+            swirl-macos
+            swirl-windows.exe


### PR DESCRIPTION
This action will allow releasing new version easier. It takes the sha of the commit that you want to include in the release and the version name. It will build swirl for every os Linux, macOS and Windows and release a new version with the binaries for the respective os.
Operating os's ussed:
Linux: Ubuntu 20.04
macOS: macOS Big Sur 11
Windows: Windows Server 2022
