### PR TITLE
Refactor CLI with improved argument handling

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,20 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+AllowShortFunctionsOnASingleLine: Empty
+ColumnLimit: 120
+BraceWrapping:
+    AfterFunction: false
+    AfterClass: false
+    AfterControlStatement: false
+    AfterEnum: false
+    AfterStruct: false
+    BeforeElse: false
+    IndentBraces: false
+SpaceBeforeParens: ControlStatements
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceAfterCStyleCast: true
+SortIncludes: false
+PointerAlignment: Left

--- a/compiler/include/cli/cli.h
+++ b/compiler/include/cli/cli.h
@@ -17,8 +17,9 @@ struct Argument {
 	std::tuple<std::string, std::string> flags;
 	std::string desc;
 
-	bool value_required;
-	std::string value{};
+  bool value_required;
+  bool repeatable = false; // Add this
+  std::vector<std::string> values{}; // Change this from std::string
 };	
 
 class cli {
@@ -28,6 +29,7 @@ public:
 public:
 	bool contains_flag(std::string_view flag);
 	std::string get_flag_value(std::string_view flag);
+  std::vector<std::string> get_flag_values(std::string_view flag); // Add this
     std::string generate_help();
 
 	std::optional<std::string> get_file();

--- a/compiler/include/cli/cli.h
+++ b/compiler/include/cli/cli.h
@@ -1,11 +1,9 @@
 #pragma once
+#include <array>
+#include <string>
 #include <vector>
 #include <variant>
 #include <string_view>
-#include <algorithm>
-#include <optional>
-#include <iostream>
-#include <tuple>
 
 const std::string USAGE = R"(The Swirl compiler
 Usage: Swirl <input-file> [flags]

--- a/compiler/include/cli/cli.h
+++ b/compiler/include/cli/cli.h
@@ -14,28 +14,27 @@ Flags:
 )";
 
 struct Argument {
-	std::tuple<std::string, std::string> flags;
-	std::string desc;
+    std::tuple<std::string, std::string> flags;
+    std::string desc;
 
   bool value_required;
   bool repeatable = false; // Add this
-  std::vector<std::string> values{}; // Change this from std::string
+  std::vector<std::string> values; // Change this from std::string
 };	
 
 class cli {
 public:
-	cli(int argc, const char** argv, const std::vector<Argument>& flags);
+    cli(int argc, const char** argv, const std::vector<Argument>& flags);
 
-public:
-	bool contains_flag(std::string_view flag);
-	std::string get_flag_value(std::string_view flag);
-  std::vector<std::string> get_flag_values(std::string_view flag); // Add this
+    bool contains_flag(std::string_view flag);
+    std::string get_flag_value(std::string_view flag);
+    std::vector<std::string> get_flag_values(std::string_view flag); // Add this
     std::string generate_help();
 
-	std::optional<std::string> get_file();
+    std::optional<std::string> get_file();
 
 private:
-	std::vector<Argument> parse();
+    std::vector<Argument> parse();
 
     /**
     * This function returns the value of the flag requested from the provided args vector.
@@ -49,11 +48,10 @@ private:
     */
     std::variant<std::string, bool> get_flag(std::string_view flag);
 
-private:
-	int m_argc;
-	const char ** m_argv;
+    int m_argc;
+    const char ** m_argv;
 
-	const std::vector<Argument> *m_flags;
-  std::string m_input_file;
-  std::vector<Argument> m_args;
+    const std::vector<Argument> *m_flags;
+    std::string m_input_file;
+    std::vector<Argument> m_args;
 };

--- a/compiler/include/cli/cli.h
+++ b/compiler/include/cli/cli.h
@@ -54,5 +54,6 @@ private:
 	const char ** m_argv;
 
 	const std::vector<Argument> *m_flags;
+  std::string m_input_file;
   std::vector<Argument> m_args;
 };

--- a/compiler/include/cli/cli.h
+++ b/compiler/include/cli/cli.h
@@ -17,13 +17,13 @@ struct Argument {
     std::tuple<std::string, std::string> flags;
     std::string desc;
 
-  bool value_required;
-  bool repeatable = false; // Add this
-  std::vector<std::string> values; // Change this from std::string
-};	
+    bool value_required;
+    bool repeatable = false;         // Add this
+    std::vector<std::string> values; // Change this from std::string
+};
 
 class cli {
-public:
+  public:
     cli(int argc, const char** argv, const std::vector<Argument>& flags);
 
     bool contains_flag(std::string_view flag);
@@ -33,25 +33,25 @@ public:
 
     std::optional<std::string> get_file();
 
-private:
+  private:
     std::vector<Argument> parse();
 
     /**
-    * This function returns the value of the flag requested from the provided args vector.
-    * If the flag is not supplied, it returns false.
-    * If the flag is supplied, it returns the value of the flag.
-    * If the flag is not required to have a value, it returns true.
-    *
-    * @param flag Requested flag
-    * @param args Vector of arguments
-    * @return The value of the flag
-    */
+     * This function returns the value of the flag requested from the provided args vector.
+     * If the flag is not supplied, it returns false.
+     * If the flag is supplied, it returns the value of the flag.
+     * If the flag is not required to have a value, it returns true.
+     *
+     * @param flag Requested flag
+     * @param args Vector of arguments
+     * @return The value of the flag
+     */
     std::variant<std::string, bool> get_flag(std::string_view flag);
 
     int m_argc;
-    const char ** m_argv;
+    const char** m_argv;
 
-    const std::vector<Argument> *m_flags;
+    const std::vector<Argument>* m_flags;
     std::string m_input_file;
     std::vector<Argument> m_args;
 };

--- a/compiler/include/cli/cli.h
+++ b/compiler/include/cli/cli.h
@@ -31,7 +31,7 @@ class cli {
     std::vector<std::string> get_flag_values(std::string_view flag); // Add this
     std::string generate_help();
 
-    std::optional<std::string> get_file();
+    std::string get_file();
 
   private:
     std::vector<Argument> parse();

--- a/compiler/include/cli/cli.h
+++ b/compiler/include/cli/cli.h
@@ -14,7 +14,7 @@ Flags:
 )";
 
 struct Argument {
-    std::tuple<std::string, std::string> flags;
+    std::array<std::string, 2> flags;
     std::string desc;
 
     bool value_required;

--- a/compiler/src/cli/cli.cpp
+++ b/compiler/src/cli/cli.cpp
@@ -1,5 +1,4 @@
 #include "cli/cli.h"
-#include <algorithm>
 
 cli::cli(int argc, const char** argv, const std::vector<Argument>& flags):
     m_argc(argc),

--- a/compiler/src/cli/cli.cpp
+++ b/compiler/src/cli/cli.cpp
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #include "cli/cli.h"
 
 cli::cli(int argc, const char** argv, const std::vector<Argument>& flags)

--- a/compiler/src/cli/cli.cpp
+++ b/compiler/src/cli/cli.cpp
@@ -65,18 +65,18 @@ std::vector<Argument> cli::parse() {
     std::vector<std::string_view> args(m_argv, m_argv + m_argc);
     std::vector<Argument> supplied;
 
-    for (auto arg_iterator = args.cbegin() + 1; arg_iterator != args.cend(); ++arg_iterator) {
+    for (auto arg_it = args.cbegin() + 1; arg_it != args.cend(); ++arg_it) {
         // if the current argument starts with `-` sign, its a flag
-        if (arg_iterator->starts_with("-")) {
+        if (arg_it->starts_with("-")) {
 
             // check if the flag exists in the flag vector
             auto flag_it = std::find_if(m_flags->cbegin(), m_flags->cend(), [&](const Argument& a) {
                 auto& [f1, f2] = a.flags;
-                return f1 == *arg_iterator || f2 == *arg_iterator;
+                return f1 == *arg_it || f2 == *arg_it;
             });
 
             if (flag_it == m_flags->cend()) {
-                std::cerr << "Unknown flag: " << *arg_iterator << '\n';
+                std::cerr << "Unknown flag: " << *arg_it << '\n';
                 exit(1);
             }
 
@@ -87,27 +87,27 @@ std::vector<Argument> cli::parse() {
 
             if (supplied_it != supplied.end()) { // Flag was already seen
                 if (!supplied_it->repeatable) {
-                    std::cerr << "Flag " << *arg_iterator << " cannot be repeated.\n";
+                    std::cerr << "Flag " << *arg_it << " cannot be repeated.\n";
                     exit(1);
                 }
                 // It's repeatable, add the new value
                 if (flag_it->value_required) {
-                    if (arg_iterator + 1 == args.cend() || (*(arg_iterator + 1)).starts_with("-")) {
-                        std::cout << "Value missing for the flag: " << *arg_iterator << '\n';
+                    if (arg_it + 1 == args.cend() || (*(arg_it + 1)).starts_with("-")) {
+                        std::cout << "Value missing for the flag: " << *arg_it << '\n';
                         exit(1);
                     }
-                    supplied_it->values.push_back(std::string(*(arg_iterator + 1)));
-                    ++arg_iterator; // Consume the value
+                    supplied_it->values.push_back(std::string(*(arg_it + 1)));
+                    ++arg_it; // Consume the value
                 }
             } else { // First time seeing this flag
                 Argument _arg = *flag_it;
                 if (_arg.value_required) {
-                    if (arg_iterator + 1 == args.cend() || (*(arg_iterator + 1)).starts_with("-")) {
-                        std::cout << "Value missing for the flag: " << *arg_iterator << '\n';
+                    if (arg_it + 1 == args.cend() || (*(arg_it + 1)).starts_with("-")) {
+                        std::cout << "Value missing for the flag: " << *arg_it << '\n';
                         exit(1);
                     }
-                    _arg.values.push_back(std::string(*(arg_iterator + 1)));
-                    ++arg_iterator; // Consume the value
+                    _arg.values.push_back(std::string(*(arg_it + 1)));
+                    ++arg_it; // Consume the value
                 }
                 supplied.push_back(_arg);
             }
@@ -116,7 +116,7 @@ std::vector<Argument> cli::parse() {
                 std::cerr << "Multiple input files provided. Only one input file is allowed.\n";
                 exit(1);
             }
-            m_input_file = *arg_iterator;
+            m_input_file = *arg_it;
         }
     }
 

--- a/compiler/src/cli/cli.cpp
+++ b/compiler/src/cli/cli.cpp
@@ -5,6 +5,7 @@ cli::cli(int argc, const char** argv, const std::vector<Argument>& flags):
 	m_argc(argc),
 	m_argv(argv),
 	m_flags(&flags),
+	m_input_file(),
   m_args(parse()) { }
 
 bool cli::contains_flag(std::string_view flag) {
@@ -54,19 +55,7 @@ std::string cli::generate_help() {
 }
 
 std::optional<std::string> cli::get_file() {
-	for (int i = 1; i < m_argc; i++) {
-		if (
-			m_argv[i][0] != '-' &&
-			(m_argv[i - 1][0] != '-' ||
-			std::find_if(m_flags -> begin(), m_flags -> end(), [&](const Argument& _arg) {
-				if (_arg.value_required) return false;
-				auto &[f1, f2] = _arg.flags;
-				return f1 == m_argv[i - 1] || f2 == m_argv[i - 1];
-			}) != m_flags -> end()
-		)) {
-			return m_argv[i];
-		}
-	} return {};
+	return m_input_file;
 }
 
 std::vector<Argument> cli::parse() {
@@ -121,6 +110,13 @@ std::vector<Argument> cli::parse() {
                 }
                 supplied.push_back(_arg);
             }
+        }
+        else {
+            if(!m_input_file.empty()) {
+                std::cerr << "Multiple input files provided. Only one input file is allowed.\n";
+                exit(1);
+            }
+            m_input_file = *arg_iterator;
         }
     }
 

--- a/compiler/src/cli/cli.cpp
+++ b/compiler/src/cli/cli.cpp
@@ -2,11 +2,11 @@
 #include <algorithm>
 
 cli::cli(int argc, const char** argv, const std::vector<Argument>& flags):
-	m_argc(argc),
-	m_argv(argv),
-	m_flags(&flags),
-	m_input_file(),
-  m_args(parse()) { }
+    m_argc(argc),
+    m_argv(argv),
+    m_flags(&flags),
+    m_input_file(),
+    m_args(parse()) { }
 
 bool cli::contains_flag(std::string_view flag) {
     return std::any_of(m_args.cbegin(), m_args.cend(), [&](const Argument& a) {
@@ -39,45 +39,45 @@ std::vector<std::string> cli::get_flag_values(std::string_view flag) {
 }
 
 std::string cli::generate_help() {
-	std::size_t max_width = 0;
-	std::for_each(m_flags -> cbegin(), m_flags -> cend(), [&](const Argument& arg) {
-		auto& [f1, f2] = arg.flags;
-		if (f1.size() + f2.size() + 2 > max_width) max_width = f1.size() + f2.size() + 3;
-	});
+    std::size_t max_width = 0;
+    std::for_each(m_flags->cbegin(), m_flags->cend(), [&](const Argument& arg) {
+        auto& [f1, f2] = arg.flags;
+        if (f1.size() + f2.size() + 2 > max_width) max_width = f1.size() + f2.size() + 3;
+    });
 
-	std::string msg;
-	for (const Argument& arg : *m_flags) {
-		auto& [f1, f2] = arg.flags;
-		msg += "\t" + f1 + ", " + f2;
-		for (unsigned int c = 0; c < max_width - f1.size() - f2.size() - 2; c++) msg += ' ';
-		msg += "     " + arg.desc + '\n';
-	} return msg;
+    std::string msg;
+    for (const Argument& arg : *m_flags) {
+        auto& [f1, f2] = arg.flags;
+        msg += "\t" + f1 + ", " + f2;
+        for (unsigned int c = 0; c < max_width - f1.size() - f2.size() - 2; c++) msg += ' ';
+        msg += "     " + arg.desc + '\n';
+    } return msg;
 }
 
 std::optional<std::string> cli::get_file() {
-	return m_input_file;
+    return m_input_file;
 }
 
 std::vector<Argument> cli::parse() {
-	if (m_argc <= 1) { 
-		std::cout << USAGE << generate_help() << '\n';
-		exit(0); 
-	}
+    if (m_argc <= 1) { 
+        std::cout << USAGE << generate_help() << '\n';
+        exit(0); 
+    }
 
-	std::vector<std::string_view> args(m_argv, m_argv + m_argc);
-	std::vector<Argument> supplied;
+    std::vector<std::string_view> args(m_argv, m_argv + m_argc);
+    std::vector<Argument> supplied;
 
-	for (auto arg_iterator = args.cbegin() + 1; arg_iterator != args.cend(); ++arg_iterator) {
-		// if the current argument starts with `-` sign, its a flag
-		if (arg_iterator->starts_with("-")) {
+    for (auto arg_iterator = args.cbegin() + 1; arg_iterator != args.cend(); ++arg_iterator) {
+        // if the current argument starts with `-` sign, its a flag
+        if (arg_iterator->starts_with("-")) {
 
             // check if the flag exists in the flag vector
-            auto flag_it = std::find_if(m_flags -> cbegin(), m_flags -> cend(), [&](const Argument& a) {
-				auto& [f1, f2] = a.flags;
-				return f1 == *arg_iterator || f2 == *arg_iterator;
+            auto flag_it = std::find_if(m_flags->cbegin(), m_flags->cend(), [&](const Argument& a) {
+                auto& [f1, f2] = a.flags;
+                return f1 == *arg_iterator || f2 == *arg_iterator;
             });
 
-            if (flag_it == m_flags -> cend()) { std::cerr << "Unknown flag: " << *arg_iterator << '\n'; exit(1); }
+            if (flag_it == m_flags->cend()) { std::cerr << "Unknown flag: " << *arg_iterator << '\n'; exit(1); }
 
             // Check if this flag was already supplied
             auto supplied_it = std::find_if(supplied.begin(), supplied.end(), [&](const Argument& a) {
@@ -120,5 +120,5 @@ std::vector<Argument> cli::parse() {
         }
     }
 
-	return supplied;
+    return supplied;
 }

--- a/compiler/src/cli/cli.cpp
+++ b/compiler/src/cli/cli.cpp
@@ -94,14 +94,20 @@ std::vector<Argument> cli::parse() {
                 }
                 // It's repeatable, add the new value
                 if (flag_it->value_required) {
-                    if (arg_iterator + 1 == args.cend()) { std::cout << "Value missing for the flag: " << *arg_iterator << '\n'; exit(1); }
+                    if (arg_iterator + 1 == args.cend() || (*(arg_iterator + 1)).starts_with("-")) {
+                        std::cout << "Value missing for the flag: " << *arg_iterator << '\n';
+                        exit(1);
+                    }
                     supplied_it->values.push_back(std::string(*(arg_iterator + 1)));
                     ++arg_iterator; // Consume the value
                 }
             } else { // First time seeing this flag
                 Argument _arg = *flag_it;
                 if (_arg.value_required) {
-                    if (arg_iterator + 1 == args.cend()) { std::cout << "Value missing for the flag: " << *arg_iterator << '\n'; exit(1); }
+                    if (arg_iterator + 1 == args.cend() || (*(arg_iterator + 1)).starts_with("-")) {
+                        std::cout << "Value missing for the flag: " << *arg_iterator << '\n';
+                        exit(1);
+                    }
                     _arg.values.push_back(std::string(*(arg_iterator + 1)));
                     ++arg_iterator; // Consume the value
                 }

--- a/compiler/src/cli/cli.cpp
+++ b/compiler/src/cli/cli.cpp
@@ -52,7 +52,7 @@ std::string cli::generate_help() {
     return msg;
 }
 
-std::optional<std::string> cli::get_file() {
+std::string cli::get_file() {
     return m_input_file;
 }
 

--- a/compiler/src/cli/cli.cpp
+++ b/compiler/src/cli/cli.cpp
@@ -15,7 +15,14 @@ bool cli::contains_flag(std::string_view flag) {
 }
 
 std::string cli::get_flag_value(std::string_view flag) {
-    return std::get<std::string>(get_flag(flag));
+    auto it = std::find_if(m_args.cbegin(), m_args.cend(), [&](const Argument& a) {
+        auto& [f1, f2] = a.flags;
+        return f1 == flag || f2 == flag;
+    });
+    if (it != m_args.cend() && !it->values.empty()) {
+        return it->values.front();
+    }
+    return "";
 }
 
 std::vector<std::string> cli::get_flag_values(std::string_view flag) {
@@ -118,20 +125,4 @@ std::vector<Argument> cli::parse() {
     }
 
 	return supplied;
-}
-
-std::variant<std::string, bool> cli::get_flag(std::string_view flag) {
-	auto it = std::find_if(m_args.cbegin(), m_args.cend(), [&](const Argument& a) {
-		auto& [f1, f2] = a.flags;
-		return f1 == flag || f2 == flag;
-	});
-
-	// Flag not found
-	if (it == m_args.cend()) return false;
-
-	// Flag exists
-	if (!it->value_required) return true;
-
-	// For repeatable flags, return the first value for backward compatibility
-	return it->values.empty() ? "" : it->values.front();
 }

--- a/compiler/src/cli/cli.cpp
+++ b/compiler/src/cli/cli.cpp
@@ -1,11 +1,7 @@
 #include "cli/cli.h"
 
-cli::cli(int argc, const char** argv, const std::vector<Argument>& flags):
-    m_argc(argc),
-    m_argv(argv),
-    m_flags(&flags),
-    m_input_file(),
-    m_args(parse()) { }
+cli::cli(int argc, const char** argv, const std::vector<Argument>& flags)
+    : m_argc(argc), m_argv(argv), m_flags(&flags), m_input_file(), m_args(parse()) {}
 
 bool cli::contains_flag(std::string_view flag) {
     return std::any_of(m_args.cbegin(), m_args.cend(), [&](const Argument& a) {
@@ -41,16 +37,19 @@ std::string cli::generate_help() {
     std::size_t max_width = 0;
     std::for_each(m_flags->cbegin(), m_flags->cend(), [&](const Argument& arg) {
         auto& [f1, f2] = arg.flags;
-        if (f1.size() + f2.size() + 2 > max_width) max_width = f1.size() + f2.size() + 3;
+        if (f1.size() + f2.size() + 2 > max_width)
+            max_width = f1.size() + f2.size() + 3;
     });
 
     std::string msg;
     for (const Argument& arg : *m_flags) {
         auto& [f1, f2] = arg.flags;
         msg += "\t" + f1 + ", " + f2;
-        for (unsigned int c = 0; c < max_width - f1.size() - f2.size() - 2; c++) msg += ' ';
+        for (unsigned int c = 0; c < max_width - f1.size() - f2.size() - 2; c++)
+            msg += ' ';
         msg += "     " + arg.desc + '\n';
-    } return msg;
+    }
+    return msg;
 }
 
 std::optional<std::string> cli::get_file() {
@@ -58,9 +57,9 @@ std::optional<std::string> cli::get_file() {
 }
 
 std::vector<Argument> cli::parse() {
-    if (m_argc <= 1) { 
+    if (m_argc <= 1) {
         std::cout << USAGE << generate_help() << '\n';
-        exit(0); 
+        exit(0);
     }
 
     std::vector<std::string_view> args(m_argv, m_argv + m_argc);
@@ -76,7 +75,10 @@ std::vector<Argument> cli::parse() {
                 return f1 == *arg_iterator || f2 == *arg_iterator;
             });
 
-            if (flag_it == m_flags->cend()) { std::cerr << "Unknown flag: " << *arg_iterator << '\n'; exit(1); }
+            if (flag_it == m_flags->cend()) {
+                std::cerr << "Unknown flag: " << *arg_iterator << '\n';
+                exit(1);
+            }
 
             // Check if this flag was already supplied
             auto supplied_it = std::find_if(supplied.begin(), supplied.end(), [&](const Argument& a) {
@@ -109,9 +111,8 @@ std::vector<Argument> cli::parse() {
                 }
                 supplied.push_back(_arg);
             }
-        }
-        else {
-            if(!m_input_file.empty()) {
+        } else {
+            if (!m_input_file.empty()) {
                 std::cerr << "Multiple input files provided. Only one input file is allowed.\n";
                 exit(1);
             }

--- a/compiler/src/swirl.cpp
+++ b/compiler/src/swirl.cpp
@@ -31,14 +31,14 @@ int main(int argc, const char** argv) {
         return 0;
     }
 
-    std::optional<std::string> _file = app.get_file();
+    std::string _file = app.get_file();
 
-    if (!_file.has_value()) {
+    if (_file.empty()) {
         std::println(stderr, "No input file");
         return 1;
     }
 
-    std::filesystem::path source_file_path = *app.get_file();
+    std::filesystem::path source_file_path = _file;
 
     if (!exists(source_file_path)) {
         std::println(stderr, "File \"{}\" not found!", source_file_path.string());

--- a/compiler/src/swirl.cpp
+++ b/compiler/src/swirl.cpp
@@ -6,9 +6,8 @@
 #include <CompilerInst.h>
 #include <include/SwirlConfig.h>
 
-
 const std::vector<Argument> application_flags = {
-    {{"-h","--help"}, "Show the help message", false, {}},
+    {{"-h", "--help"}, "Show the help message", false, {}},
     {{"-o", "--output"}, "Output file name", true, {}},
     {{"-v", "--version"}, "Show the version of Swirl", false, {}},
     {{"-j", "--threads"}, "No. of threads to use (excluding the main-thread).", true},
@@ -18,7 +17,6 @@ const std::vector<Argument> application_flags = {
     {{"-d", "--dependency"}, "Register a dependency, in the format `path:name`.", true, true},
     {{"-Ld", "--debug"}, "Log the steps of compilation", false, {}},
 };
-
 
 int main(int argc, const char** argv) {
     cli app(argc, argv, application_flags);
@@ -50,7 +48,6 @@ int main(int argc, const char** argv) {
     auto out_dir = source_file_path.parent_path();
     auto file_name = source_file_path.filename();
 
-
     if (!source_file_path.empty()) {
         if (!source_file_path.is_absolute())
             source_file_path = absolute(source_file_path);
@@ -61,29 +58,25 @@ int main(int argc, const char** argv) {
             compiler_inst.setBaseThreadCount(app.get_flag_value("-j"));
         if (app.contains_flag("-t"))
             CompilerInst::setTargetTriple(app.get_flag_value("-t"));
-        if (app.contains_flag("-l"))  {
-            for(auto lib: app.get_flag_values("-l"))
+        if (app.contains_flag("-l")) {
+            for (auto lib : app.get_flag_values("-l"))
                 CompilerInst::appendLinkTarget(lib);
         }
         if (app.contains_flag("-d")) {
             // format: `path:alias`
-            for(auto dep: app.get_flag_values("-d"))
+            for (auto dep : app.get_flag_values("-d"))
                 CompilerInst::addPackageEntry(dep);
         }
         if (app.contains_flag("-p"))
             CompilerInst::addPackageEntry(
-                app.get_flag_value("-p") + ':' + fs::path(app.get_flag_value("-p")).filename().string(),
-                true
-                );
+                app.get_flag_value("-p") + ':' + fs::path(app.get_flag_value("-p")).filename().string(), true);
         else {
             // if `-p` isn't passed explicitly, assume that the project root is the
             // directory in which the source file resides
-            CompilerInst::addPackageEntry(
-                source_file_path.parent_path().string() + ':' + source_file_path.parent_path().filename().string(),
-                true
-                );
+            CompilerInst::addPackageEntry(source_file_path.parent_path().string() + ':' +
+                                              source_file_path.parent_path().filename().string(),
+                                          true);
         }
-
 
         compiler_inst.compile();
     }

--- a/compiler/src/swirl.cpp
+++ b/compiler/src/swirl.cpp
@@ -13,9 +13,9 @@ const std::vector<Argument> application_flags = {
     {{"-v", "--version"}, "Show the version of Swirl", false, {}},
     {{"-j", "--threads"}, "No. of threads to use (excluding the main-thread).", true},
     {{"-t", "--target"}, "The target-triple of the target-platform", true},
-    {{"-l", "--library"}, "The name of the library to link against.", true},
+    {{"-l", "--library"}, "The name of the library to link against.", true, true},
     {{"-p", "--project"}, "/path/to/project/root", true},
-    {{"-d", "--dependency"}, "Register a dependency, in the format `path:name`.", true},
+    {{"-d", "--dependency"}, "Register a dependency, in the format `path:name`.", true, true},
     {{"-Ld", "--debug"}, "Log the steps of compilation", false, {}},
 };
 
@@ -61,11 +61,14 @@ int main(int argc, const char** argv) {
             compiler_inst.setBaseThreadCount(app.get_flag_value("-j"));
         if (app.contains_flag("-t"))
             CompilerInst::setTargetTriple(app.get_flag_value("-t"));
-        if (app.contains_flag("-l"))  // until the cli supports multiple-values for the same flag...
-            CompilerInst::appendLinkTarget(app.get_flag_value("-l"));
-        if (app.contains_flag("-d")) { // until the cli supports multiple-values for the same flag...
+        if (app.contains_flag("-l"))  {
+            for(auto lib: app.get_flag_values("-l"))
+                CompilerInst::appendLinkTarget(lib);
+        }
+        if (app.contains_flag("-d")) {
             // format: `path:alias`
-            CompilerInst::addPackageEntry(app.get_flag_value("-d"));
+            for(auto dep: app.get_flag_values("-d"))
+                CompilerInst::addPackageEntry(dep);
         }
         if (app.contains_flag("-p"))
             CompilerInst::addPackageEntry(


### PR DESCRIPTION


**Flag handling improvements:**

* Added a `repeatable` boolean and changed the `value` field to a `values` vector in the `Argument` struct to support flags that can accept multiple values. (`compiler/include/cli/cli.h`)
* Introduced the `get_flag_values` method to retrieve all values for a flag, and updated `get_flag_value` to return the first value only. (`compiler/include/cli/cli.h`, `compiler/src/cli/cli.cpp`) [[1]](diffhunk://#diff-3908e0f696019670b672294086493adb98c35da3a44ee95b25791fbfc8fb4791R32) [[2]](diffhunk://#diff-15dca48ba8e5a1c4419aac5488118c473d101a419f020a221bc5c97dd224dedbR2-R58)
* Updated the parsing logic to handle repeatable flags, ensuring that non-repeatable flags cannot be supplied more than once, and that repeatable flags can accumulate multiple values. (`compiler/src/cli/cli.cpp`)

**Input file handling:**

* Changed input file handling to store the input file in `m_input_file` and enforce that only one input file can be provided, with an error if multiple are given. (`compiler/include/cli/cli.h`, `compiler/src/cli/cli.cpp`) [[1]](diffhunk://#diff-3908e0f696019670b672294086493adb98c35da3a44ee95b25791fbfc8fb4791R57) [[2]](diffhunk://#diff-15dca48ba8e5a1c4419aac5488118c473d101a419f020a221bc5c97dd224dedbL67-R123)

**Code cleanup and consistency:**

* Replaced variable names for flag identifiers from `v1`, `v2` to `f1`, `f2` for clarity and consistency across the codebase. (`compiler/src/cli/cli.cpp`) [[1]](diffhunk://#diff-15dca48ba8e5a1c4419aac5488118c473d101a419f020a221bc5c97dd224dedbR2-R58) [[2]](diffhunk://#diff-15dca48ba8e5a1c4419aac5488118c473d101a419f020a221bc5c97dd224dedbL67-R123)